### PR TITLE
JMAP8-2882: An error occured when exporting a QGIS project to JMap Cloud

### DIFF
--- a/core/services/export_project_manager.py
+++ b/core/services/export_project_manager.py
@@ -73,7 +73,7 @@ class ExportProjectManager(QObject):
             self._finish(False)
             return
         self.action_dialog.set_text(self.tr("Converting layers to zip"))
-        self.dir = tempfile.TemporaryDirectory(delete=True)
+        self.dir = tempfile.TemporaryDirectory()
         convert_layer_to_zip_task = ConvertLayersToZipTask(self.dir.name, self.project_data.layers)
         convert_layer_to_zip_task.progress_changed.connect(
             lambda value, current_step=self.current_step: self.set_progress(value, current_step)

--- a/metadata.txt
+++ b/metadata.txt
@@ -41,10 +41,12 @@ deprecated=False
 server=False
 
 changelog=
+    1.0.2
+    - Fixed an error that occurred when exporting a QGIS project to JMap Cloud
     1.0.1
-    - Fix the Layer problem Layout on MacOS.
-    - Cosmetic fiexes.
-    - The popup in QGIS doesn't not show the data
+    - Fixed a layer layout problem on MacOS
+    - Cosmetic fixes
+    - The popup in QGIS does not show the layer data
     1.0.0
     - First version.
 


### PR DESCRIPTION
Issue:
- [JMAP8-2881](https://k2geospatial.atlassian.net/browse/JMAP8-2881)